### PR TITLE
More doorhanger nits

### DIFF
--- a/phase1/addon/data/ui/doorhanger.html
+++ b/phase1/addon/data/ui/doorhanger.html
@@ -35,8 +35,19 @@
 	  font-family: 'clear_sansregular'; }
 
 	ul, ol, p {
-	  line-height: 24px;
-	  margin: 1em 0 0em 0; }
+	  line-height: 20px;
+	  margin: .5em 0 0em 0; 
+	}
+
+	/* specific heights we like */
+
+	h1 {
+		font-size:18px;
+	}
+
+	p {
+		font-size:18px;
+	}
 
 			/*div {border: solid 1px black}*/
 			body {
@@ -98,7 +109,7 @@
 			#alltext {
 				/*height: 20%;*/
   				position: absolute;
-  				top: 30px; left: 0; bottom: 0; right: 0;
+  				top: 24px; left: 0; bottom: 0; right: 0;
   				text-align: left;
   				padding-right: 15px;
   				/*font-family: 'Helvetica Neue', Helvetica, sans-serif;*/


### PR DESCRIPTION
13:25 < kamyar> gregglind, re styling: isn't the space between the lines of the message text too much?
13:26 < kamyar> it kind of looks like they are in separate paragraphs
13:42 @gregglind They are in sep paras :)
13:42 @gregglind Well spotted, kamyar.
13:42 @gregglind THey were sep before.  If you want to tight then that, do so.
13:43 @gregglind (by chaninging the para margin or padding, or tell me to do that!
13:45 < kamyar> it'd be great if you could do it
13:46 @gregglind Thanks, what's the beef?  Just too much space?  Any other styling?  How obvious is the explanation
13:46 @gregglind or how much shuld it be.
13:48 < kamyar> ok, let me go over it
13:50 < kamyar> so I think the title is a bit big
13:51 < kamyar> the line spacing should be less in the message para (#textbox)
13:52 < kamyar> the text of #textbox could also be a bit larger
13:53 @gregglind line spacing = line hight or before / after
13:53 < kamyar> (something like the one on the tour panel)
13:53 @gregglind okay, will attempt :)
13:53 < kamyar> line height
13:54 @gregglind got it.  and this is a new pull right?
13:54 @gregglind So I will open a bug on it.
