### PR TITLE
remove querystring warning from 3rdparty blush.

### DIFF
--- a/phase1/addon/Makefile
+++ b/phase1/addon/Makefile
@@ -40,9 +40,9 @@ help:
 	@echo "$$HELPDOC"
 
 deps:
-	# blushproof
-	#curl --create-dirs https://raw.githubusercontent.com/mozilla/blushproof/master/lib/bpUtil.js > lib/thirdparty/blushproof/bpUtil.js
-	#curl --create-dirs https://raw.githubusercontent.com/mozilla/blushproof/master/lib/blushlist.js > lib/thirdparty/blushproof/blushlist.js
+	@# blushproof
+	@#curl --create-dirs https://raw.githubusercontent.com/mozilla/blushproof/master/lib/bpUtil.js > lib/thirdparty/blushproof/bpUtil.js
+	@#curl --create-dirs https://raw.githubusercontent.com/mozilla/blushproof/master/lib/blushlist.js > lib/thirdparty/blushproof/blushlist.js
 	@# wget micropilot
 	@#curl https://raw.github.com/gregglind/micropilot/dev/lib/micropilot.js > lib/micropilot.js
 	@# wget bwclarks thing

--- a/phase1/addon/lib/thirdparty/blushproof/bpUtil.js
+++ b/phase1/addon/lib/thirdparty/blushproof/bpUtil.js
@@ -5,7 +5,7 @@
 "use strict";
 
 const { Cc, Ci } = require("chrome");
-let querystring = require("querystring");
+let querystring = require("sdk/querystring");
 
 let eTLDService = Cc["@mozilla.org/network/effective-tld-service;1"]
                     .getService(Ci.nsIEffectiveTLDService);


### PR DESCRIPTION
We keep our own copy anyway, so fix it.
